### PR TITLE
Docs: fix console.log comment in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ fn('Hello World!')
 fn('Hi!', (error, result) => {
   if (error) return console.error(error)
   console.log(result)
-  // -> Hello World!
+  // -> Hi!
 })
 ```
 
@@ -64,7 +64,7 @@ fn('Hello World!')
 fn('Hi!', (error, result) => {
   if (error) return console.error(error)
   console.log(result)
-  // -> Hello World!
+  // -> Hi!
 })
 ```
 


### PR DESCRIPTION
I guess the expected output of `fn('Hi!', ...)` is `Hi!`.