### PR TITLE
Coerce undefined to null in fromPromise to suppress Bluebird warning

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,14 @@ exports.fromPromise = function (fn) {
   return Object.defineProperty(function () {
     const cb = arguments[arguments.length - 1]
     if (typeof cb !== 'function') return fn.apply(this, arguments)
-    else fn.apply(this, arguments).then(r => cb(null, r)).catch(cb)
+    else {
+      fn.apply(this, arguments)
+        .then(r => {
+          const result = cb(null, r)
+          if (result === undefined) return null
+          return result
+        })
+        .catch(cb)
+    }
   }, 'name', { value: fn.name })
 }


### PR DESCRIPTION
This suppresses Bluebird `Promise`'s generation of"Warning: a promise was created in a handler at **/projectpath**/node_modules/universalify/index.js:26:20 but was not returned from it, see http://goo.gl/rRqMUw. This is done by returning null instead of undefined in the `.then` handler.