### PR TITLE
Use spread syntax to make fromCallback faster

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,9 +5,10 @@ exports.fromCallback = function (fn) {
     if (typeof args[args.length - 1] === 'function') fn.apply(this, args)
     else {
       return new Promise((resolve, reject) => {
-        fn.apply(
+        fn.call(
           this,
-          args.concat([(err, res) => err ? reject(err) : resolve(res)])
+          ...args,
+          (err, res) => err ? reject(err) : resolve(res)
         )
       })
     }


### PR DESCRIPTION
![Selection_999(394)](https://user-images.githubusercontent.com/1663259/87566515-6eea6980-c6c3-11ea-9397-873d4d727f13.png)

```js
"use strict";

const benchmark = require("benchmark");

let suite = new benchmark.Suite();

function someFunc(one, two, three) {
	return one + two + three;
}

function usingConcat(... args) {
	return someFunc.apply(this, args.concat([ 3 ]))
}

function usingRestCall(... args) {
	return someFunc.call(this, ... args, 3);
}

function usingRest(... args) {
	return someFunc(... args, 3);
}

suite
	.add("concat + apply", () => {
		usingConcat(1, 2);
	})
	.add("rest + call", () => {
		usingRestCall(1, 2);
	})
	.add("rest", () => {
		usingRest(1, 2);
	})
	.on("cycle", (event) => {
		console.log(String(event.target));
	})
	.on("complete", function () {
		console.log('Fastest is ' + this.filter('fastest').map('name'));
	})
	.run({
		async: true
	});
```