### PR TITLE
Optionally allow false as a "no error" value

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,9 @@
 'use strict'
 
-exports.fromCallback = function (fn) {
+exports.fromCallback = function (fn, falseIsError) {
+  if (typeof(falseIsError) == "undefined") {
+    falseIsError = true;
+  }
   return Object.defineProperty(function (...args) {
     if (typeof args[args.length - 1] === 'function') fn.apply(this, args)
     else {
@@ -8,7 +11,7 @@ exports.fromCallback = function (fn) {
         fn.call(
           this,
           ...args,
-          (err, res) => (err != null) ? reject(err) : resolve(res)
+          (err, res) => (err == null || (err == false && !falseIsError)) ? resolve(res) : reject(err)
         )
       })
     }

--- a/test/from-callback.js
+++ b/test/from-callback.js
@@ -14,6 +14,10 @@ const falseyErrFn = universalify.fromCallback(function (cb) {
   setTimeout(() => cb(0, 15)) // eslint-disable-line standard/no-callback-literal
 })
 
+const falseWhenNoError = universalify.fromCallback(function (cb) {
+  setTimeout(() => cb(false, 100))
+}, false)
+
 test('callback function works with callbacks', t => {
   t.plan(4)
   fn.call({ a: 'a' }, 1, 2, (err, arr) => {
@@ -64,6 +68,18 @@ test('should correctly reject on falsey error values', t => {
     .catch(err => {
       t.assert((err != null), 'should error')
       t.is(err, 0)
+      t.end()
+    })
+})
+
+test('allows false as a non error value as resolve', t => {
+  t.plan(1)
+  falseWhenNoError()
+    .then(res => {
+      t.is(res, 100)
+      t.end()
+    })
+    .catch(err => {
       t.end()
     })
 })


### PR DESCRIPTION
Even though not all falsey values should be considered as non-errors
which was fixed in #13, there are built-in callbacks which use `false`
as the no-error value. (eg `fs.realpath`)

The current state breaks `fs-extra` which uses universalify to wrap
`fs.realpath` ending up with successful calls raising an exception.

In this PR I am adding an option to consider "false" error values as
"no-error".
