### PR TITLE
Relate unhandled rejections to source calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,26 @@ exports.fromCallback = function (fn) {
   return Object.defineProperty(function (...args) {
     if (typeof args[args.length - 1] === 'function') fn.apply(this, args)
     else {
+      // Capture stack trace of where the promise was created in case it rejects.
+      let caller_stack = new Error("Failing function was called from here").stack
       return new Promise((resolve, reject) => {
         fn.call(
           this,
           ...args,
-          (err, res) => (err != null) ? reject(err) : resolve(res)
+          (err, res) => {
+            if (err != null) {
+              if (err instanceof Error && typeof err.stack === 'string') {
+                // It is safe to improve the error's stack trace with
+                // information about where the Promise was created and where
+                // the err was passed from.
+                let e = new Error("Callback-based function called back with an error")
+                err.stack += "\n" + e.stack + "\n" + caller_stack
+              }
+              reject(err)
+            } else {
+              resolve(res)
+            }
+          }
         )
       })
     }


### PR DESCRIPTION
I was getting nearly untraceable unhandled rejections with errors like `Error: ENOENT: no such file or directory, mkdir '/public'` in an application. I eventually used `node --inspect` and `breakOnException` to trace them to `fs` functions being wrapped with `universalify`. The important information for debugging these errors is really the stack trace from the `universalify` wrapper's invocation, but that was not being preserved or at all attached to the error being passed to the rejection.

This makes sure to attach stack traces from the wrapper invocation and the callback invocation to the rejection errors, if they are normal `Error` objects that carry stack traces. This will make debugging failures in wrapped functions possible, because it will be possible to see where a failing wrapped function was invoked from.

The traces look like this:

```
Error: ENOENT: no such file or directory, mkdir '/public'
Error: Callback-based function called back with an error
    at /Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/node_modules/universalify/index.js:19:25
    at FSReqCallback.oncomplete (fs.js:179:23)
Error: Failing function was called from here
    at Object.mkdir (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/node_modules/universalify/index.js:8:26)
    at Object.module.exports.makeDir (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/node_modules/fs-extra/lib/mkdirs/make-dir.js:51:15)
    at Object.defineProperty.value (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/node_modules/universalify/index.js:36:45)
    at Object.execProgram (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/lib/api/cxapp/exec.ts:71:12)
    at CloudExecutable.doSynthesize (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/lib/api/cxapp/cloud-executable.ts:71:24)
    at CloudExecutable.synthesize (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/lib/api/cxapp/cloud-executable.ts:57:29)
    at CdkToolkit.selectStacksForDeploy (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/lib/cdk-toolkit.ts:486:22)
    at CdkToolkit.deploy (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/lib/cdk-toolkit.ts:120:20)
    at initCommandLine (/Users/anovak/workspace/amazon-genomics-cli/packages/cdk/node_modules/aws-cdk/bin/cdk.ts:267:9)
```