### PR TITLE
perf: manipulate arguments instead of creating new array

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,11 +5,8 @@ exports.fromCallback = function (fn) {
     if (typeof args[args.length - 1] === 'function') fn.apply(this, args)
     else {
       return new Promise((resolve, reject) => {
-        fn.call(
-          this,
-          ...args,
-          (err, res) => (err != null) ? reject(err) : resolve(res)
-        )
+        args.push((err, res) => (err != null) ? reject(err) : resolve(res))
+        fn.apply(this, args)
       })
     }
   }, 'name', { value: fn.name })
@@ -19,6 +16,9 @@ exports.fromPromise = function (fn) {
   return Object.defineProperty(function (...args) {
     const cb = args[args.length - 1]
     if (typeof cb !== 'function') return fn.apply(this, args)
-    else fn.apply(this, args.slice(0, -1)).then(r => cb(null, r), cb)
+    else {
+      args.pop()
+      fn.apply(this, args).then(r => cb(null, r), cb)
+    }
   }, 'name', { value: fn.name })
 }

--- a/test/from-callback.js
+++ b/test/from-callback.js
@@ -37,6 +37,16 @@ test('callback function works with promises', t => {
     .catch(t.end)
 })
 
+test('callbacks function works with promises without modify the original arg array', t => {
+  t.plan(2)
+  const array = [1, 2]
+  fn.apply(this, array).then((arr) => {
+    t.is(array.length, 2)
+    t.is(arr.length, 3)
+    t.end()
+  })
+})
+
 test('callback function error works with callbacks', t => {
   t.plan(2)
   errFn(err => {


### PR DESCRIPTION
This is something that `util.promisify` does and I don't that has no harm.

Before:
```
util.promisify x 22,101,833 ops/sec ±0.60% (94 runs sampled)
universalify.fromCallback x 17,859,701 ops/sec ±0.48% (98 runs sampled)
universalify.fromPromise x 12,234,774 ops/sec ±1.19% (79 runs sampled)
```

Now:
```
util.promisify x 21,313,745 ops/sec ±0.93% (94 runs sampled)
universalify.fromCallback x 21,528,063 ops/sec ±0.76% (96 runs sampled)
universalify.fromPromise x 16,615,574 ops/sec ±0.83% (82 runs sampled)
```

<details>
<summary>benchmark</summary>

```js
import benchmark from 'benchmark';
import { promisify } from 'node:util';
import { fromCallback, fromPromise } from 'universalify';

const suite = benchmark.Suite();
const callbackTest = (test, fn) => {
  fn(null, test);
}
const promiseTest = async (test) => {
  return test;
}

const utilPromisifyTest = promisify(callbackTest);
const universalifyTest = fromCallback(callbackTest);

const universalifyCallback = fromPromise(promiseTest);

suite.add('util.promisify', () => {
  utilPromisifyTest('hello');
}).add('universalify.fromCallback', () => {
  universalifyTest('hello');
}).add('universalify.fromPromise', (deferred) => {
  universalifyCallback('hello', (t) => {
    deferred.resolve();
  });
}, { defer: true })
  .on('cycle', event => {
    console.log(event.target.toString())
  })
  .run({ async: false });
```